### PR TITLE
Reorganize go code and add debug capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ The pages will now be available in the Falcon console (after refresh) under the 
 
 Foundry functions don't have a "dev mode" so we test locally and then deploy:
 
-1. Load a `FALCON_CLIENT_ID`, `FALCON_CLIENT_SECRET`, and `FALCON_CLOUD` into your environment
+1. Export the following variables into your environment:
+   -  `FALCON_CLIENT_ID`
+   - `FALCON_CLIENT_SECRET`
+   - `FALCON_CLOUD`
+   
+   If you would like to enable debug logs, export `DEBUG=true` as well.
+
 1. In `functions/syncimages`:
 
    1. `go run main.go`

--- a/functions/syncimages/falcon/falcon.go
+++ b/functions/syncimages/falcon/falcon.go
@@ -1,0 +1,88 @@
+package falcon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/crowdstrike/gofalcon/falcon"
+	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon/client/custom_storage"
+	"github.com/crowdstrike/gofalcon/falcon/client/falcon_container"
+	"github.com/crowdstrike/gofalcon/falcon/client/sensor_download"
+)
+
+// RegistryLogin gets the registry login from the CrowdStrike API using the SensorDownload API.
+func RegistryLogin(ctx context.Context, client *client.CrowdStrikeAPISpecification) (string, error) {
+	user, err := getCID(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("fc-%s", strings.ToLower(strings.Split(user, "-")[0])), nil
+}
+
+// getCID gets the Falcon CID from the CrowdStrike API using the SensorDownload API.
+func getCID(ctx context.Context, client *client.CrowdStrikeAPISpecification) (string, error) {
+	response, err := client.SensorDownload.GetSensorInstallersCCIDByQuery(&sensor_download.GetSensorInstallersCCIDByQueryParams{
+		Context: ctx,
+	})
+	if err != nil {
+		return "", fmt.Errorf("Could not get Falcon CID from CrowdStrike Falcon API: %v", err)
+	}
+	payload := response.GetPayload()
+	if err = falcon.AssertNoError(payload.Errors); err != nil {
+		return "", fmt.Errorf("Error reported when getting Falcon CID from CrowdStrike Falcon API: %v", err)
+	}
+	if len(payload.Resources) != 1 {
+		return "", fmt.Errorf("Failed to get Falcon CID: Unexpected API response: %v", payload.Resources)
+	}
+
+	return payload.Resources[0], nil
+}
+
+// RegistryToken gets the registry token from the CrowdStrike API using the FalconContainer API.
+func RegistryToken(ctx context.Context, client *client.CrowdStrikeAPISpecification) (string, error) {
+	res, err := client.FalconContainer.GetCredentials(&falcon_container.GetCredentialsParams{
+		Context: ctx,
+	})
+	if err != nil {
+		return "", err
+	}
+	payload := res.GetPayload()
+	if err = falcon.AssertNoError(payload.Errors); err != nil {
+		return "", err
+	}
+	resources := payload.Resources
+	resourcesList := resources
+	if len(resourcesList) != 1 {
+		return "", fmt.Errorf("Expected to receive exactly one token, but got %d\n", len(resourcesList))
+	}
+	valueString := *resourcesList[0].Token
+	if valueString == "" {
+		return "", fmt.Errorf("Received empty token")
+	}
+	return valueString, nil
+}
+
+// WriteToCollection writes the image list to the CrowdStrike API using the CustomStorage API.
+func WriteToCollection(client *client.CrowdStrikeAPISpecification, images interface{}) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(images); err != nil {
+		return fmt.Errorf("Error encoding image list: %v", err)
+	}
+
+	_, err := client.CustomStorage.Upload(&custom_storage.UploadParams{
+		CollectionName: "images",
+		ObjectKey:      "all",
+		Body:           io.NopCloser(&buf),
+	})
+	if err != nil {
+		return fmt.Errorf("Error storing image list in collection: %v", err)
+	}
+
+	return nil
+}

--- a/functions/syncimages/registry/registry.go
+++ b/functions/syncimages/registry/registry.go
@@ -1,0 +1,83 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/types"
+)
+
+// Config contains the user, password, and token for the registry.
+type Config struct {
+	User  string
+	Pass  string
+	Token string
+}
+
+// getImageRef returns a reference to the specified image.
+func getImageRef(sensor string) (types.ImageReference, error) {
+	ref, err := reference.ParseNormalizedNamed(sensor)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing reference: %w", err)
+	}
+
+	if !reference.IsNameOnly(ref) {
+		return nil, fmt.Errorf("No tag or digest allowed in reference: %v", ref.String())
+	}
+
+	return docker.NewReference(reference.TagNameOnly(ref))
+}
+
+// dockerConfig returns the context and system context for the Docker client.
+func (rc Config) dockerConfig() (context.Context, *types.SystemContext) {
+	ctx := context.Background()
+	sysCtx := &types.SystemContext{}
+
+	if rc.User != "" {
+		sysCtx = &types.SystemContext{
+			DockerAuthConfig: &types.DockerAuthConfig{
+				Username: rc.User,
+				Password: rc.Pass,
+			},
+		}
+	}
+
+	return ctx, sysCtx
+}
+
+// GetRepositoryTags returns a list of tags for the specified image.
+func (rc Config) GetRepositoryTags(image string) ([]string, error) {
+	ctx, sysCtx := rc.dockerConfig()
+
+	imgRef, err := getImageRef(image)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating image reference: %v", err)
+	}
+
+	tags, err := docker.GetRepositoryTags(ctx, sysCtx, imgRef)
+	if err != nil {
+		return nil, fmt.Errorf("Error listing repository tags: %w", err)
+	}
+
+	return tags, nil
+}
+
+// GetImageDigest returns the digest for the specified image and tag.
+func (rc Config) GetImageDigest(image string, tag string) (string, error) {
+	ctx, sysCtx := rc.dockerConfig()
+
+	image = fmt.Sprintf("//%s:%s", image, tag)
+	imgRef, err := docker.ParseReference(image)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing reference: %w", err)
+	}
+
+	digest, err := docker.GetDigest(ctx, sysCtx, imgRef)
+	if err != nil {
+		return "", fmt.Errorf("Error getting digest: %w", err)
+	}
+
+	return digest.String(), nil
+}


### PR DESCRIPTION
- Setting DEBUG=true as env variable will enable debug messages when running the go code
- Move registry code to its own file
- Move gofalcon code to its own file
- Update WriteToCollection function to use an interface instead of ImageList