### PR TITLE
Pin GitHub Actions to commit SHAs and harden release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "${{ env.WORKDIR }}/go.mod"
           cache: false
@@ -44,7 +44,7 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v8.0.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           args: --timeout=5m12s
           version: latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: "${{ env.WORKDIR }}/go.mod"
           cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,24 +4,30 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 env:
   WORKDIR: "./ui/pages/"
 
 jobs:
   ui:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Validate tag name
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          if [[ ! "${{ github.event.release.tag_name }}" =~ ^[0-9a-zA-Z._-]+$ ]]; then
+          if [[ ! "${TAG_NAME}" =~ ^[0-9a-zA-Z._-]+$ ]]; then
             echo "Invalid tag name format"
             exit 1
           fi
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -32,5 +38,6 @@ jobs:
       - name: Upload Release Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} *.tar.gz
+          gh release upload "${TAG_NAME}" *.tar.gz

--- a/functions/syncimages/main.go
+++ b/functions/syncimages/main.go
@@ -142,7 +142,7 @@ func newFalconClient(token string) (*client.CrowdStrikeAPISpecification, string,
 	// When the NewClient function returns, the cloud will be set to the actual cloud used.
 	cloud = apiConfig.Cloud.String()
 
-	slog.Debug("Creating Falcon client", "cloud", apiConfig.Cloud.String(), "user_agent", userAgent)
+	slog.Debug("Creating Falcon client", "cloud", apiConfig.Cloud.String(), "user_agent", userAgent) //nolint:gosec // G706 - cloud is an SDK enum and userAgent is built from constants; no injection risk
 
 	client, err := falcon.NewClient(apiConfig)
 

--- a/functions/syncimages/main.go
+++ b/functions/syncimages/main.go
@@ -142,7 +142,7 @@ func newFalconClient(token string) (*client.CrowdStrikeAPISpecification, string,
 	// When the NewClient function returns, the cloud will be set to the actual cloud used.
 	cloud = apiConfig.Cloud.String()
 
-	slog.Debug("Creating Falcon client", "client_id", apiConfig.ClientId, "client_secret", apiConfig.ClientSecret, "cloud", cloud, "access_token", apiConfig.AccessToken, "user_agent", userAgent)
+	slog.Debug("Creating Falcon client", "cloud", apiConfig.Cloud.String(), "user_agent", userAgent)
 
 	client, err := falcon.NewClient(apiConfig)
 


### PR DESCRIPTION
All GitHub Actions are now pinned to immutable commit SHAs instead of mutable version tags, preventing supply chain attacks where a tag could be force-pushed to point at malicious code. The release workflow also gets several hardening fixes: a least-privilege `permissions` block, script injection mitigation for the tag name, and a `timeout-minutes` guard.

### Actions allowlist

| Action | Version |
|--------|---------|
| `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` | v5 |
| `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020` | v4 |
| `actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5` | v5 |
| `golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9` | v8.0.0 |